### PR TITLE
Update legacy warning

### DIFF
--- a/source/layouts/header.html
+++ b/source/layouts/header.html
@@ -29,8 +29,8 @@
     </noscript>
 
     <div class="u-padding-Am u-text-center version-deprecated__warning">
-      There is a newer version of the GoCardless API
-      → <a href="/pro">View Docs</a>
+      <p>You are viewing the documentation for the Legacy GoCardless API, which is no longer actively developed.</p>
+      <p><a href="https://developer.gocardless.com">Click here</a> for the current API documentation.</p>
     </div>
 
     <header class="site-frame__header site-header u-cf">

--- a/source/stylesheets/components/deprecation-warning.scss
+++ b/source/stylesheets/components/deprecation-warning.scss
@@ -8,15 +8,17 @@
 }
 
 .version-deprecated__warning {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   position: fixed;
   right: 0;
   left: 0;
   z-index: 10000;
-  background: #F5A623;
+  background: #EE6850;
   color: #FFF;
-  font-size: 16px;
+  font-size: 18px;
   height: $deprecation-warning-height;
-  display: block;
 
   a {
     font-weight: 700;

--- a/source/stylesheets/components/section-header.scss
+++ b/source/stylesheets/components/section-header.scss
@@ -7,6 +7,8 @@
   top: -95px;
   height: 1px;
   width: 100%;
+  padding-top: $deprecation-warning-height;
+  margin-top: -$deprecation-warning-height;
 }
 
 .section-header__click-overlay {

--- a/source/stylesheets/variables.scss
+++ b/source/stylesheets/variables.scss
@@ -24,7 +24,7 @@ $box-shadow-base: 0 1px 4px rgba(0, 0, 0, 0.3);
 $gutter-space-base: 15px;
 
 $header-nav-height: 47px;
-$deprecation-warning-height: 55px;
+$deprecation-warning-height: 200px;
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
The current warning is a bit hard to read, and people ... aren't reading it.

<img width="2559" alt="screen shot 2016-11-04 at 14 05 26" src="https://cloud.githubusercontent.com/assets/6728978/20008426/70b0a34a-a298-11e6-9b52-9d4acf9f5461.png">
